### PR TITLE
Minor change in example 3 - Sketch_create_shape.txt

### DIFF
--- a/py5_docs/Reference/api_en/Sketch_create_shape.txt
+++ b/py5_docs/Reference/api_en/Sketch_create_shape.txt
@@ -65,8 +65,8 @@ def draw():
 image = Sketch_create_shape_2.png
 
 def setup():
-    py5.size(100, 100, py5.P2D)
     global s
+    py5.size(100, 100, py5.P2D)
     s = py5.create_shape()
     s.begin_shape(py5.TRIANGLE_STRIP)
     s.vertex(30, 75)


### PR DESCRIPTION
I switched the lines 68 and 69. The fact that the global declaration was after the size function made the example bug for me. ( see https://discourse.processing.org/t/issue-with-using-pshapes-in-py5/35762/2 )