### PR TITLE
Fixannoyingwarning

### DIFF
--- a/py5_resources/py5_module/py5_tools/jvm.py
+++ b/py5_resources/py5_module/py5_tools/jvm.py
@@ -30,7 +30,7 @@ import jpype
 
 _PY5_REQUIRED_JAVA_VERSION = 17
 
-_options = [""]
+_options = []
 _classpath = []
 
 


### PR DESCRIPTION
Importing py5 when Java 24 or 25 is installed results in an odd warning. This will be fixed when jpype drops support for Java 1.8, which will happen one day. Until then, this PR eliminates the warning.